### PR TITLE
feat: add ShowCommand with state/plan JSON types

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -3,5 +3,6 @@ pub mod destroy;
 pub mod init;
 pub mod output;
 pub mod plan;
+pub mod show;
 pub mod validate;
 pub mod version;

--- a/src/commands/show.rs
+++ b/src/commands/show.rs
@@ -1,0 +1,161 @@
+use crate::Terraform;
+use crate::command::TerraformCommand;
+use crate::error::Result;
+use crate::exec;
+
+/// Result from a show command.
+///
+/// The variant depends on whether a plan file was specified:
+/// - No plan file: [`ShowResult::State`] with current state
+/// - With plan file: [`ShowResult::Plan`] with plan details
+/// - Without JSON: [`ShowResult::Plain`] with raw output
+#[derive(Debug, Clone)]
+pub enum ShowResult {
+    /// Current state from `terraform show -json`.
+    #[cfg(feature = "json")]
+    State(crate::types::state::StateRepresentation),
+    /// Saved plan from `terraform show -json <planfile>`.
+    #[cfg(feature = "json")]
+    Plan(Box<crate::types::plan::PlanRepresentation>),
+    /// Plain command output (no `-json`).
+    Plain(exec::CommandOutput),
+}
+
+/// Command for inspecting current state or a saved plan.
+///
+/// With `-json`, returns structured data about the current state or a
+/// saved plan file.
+///
+/// ```no_run
+/// # async fn example() -> terraform_wrapper::error::Result<()> {
+/// use terraform_wrapper::{Terraform, TerraformCommand};
+/// use terraform_wrapper::commands::show::{ShowCommand, ShowResult};
+///
+/// let tf = Terraform::builder().working_dir("/tmp/infra").build()?;
+///
+/// // Show current state
+/// let result = ShowCommand::new().execute(&tf).await?;
+///
+/// // Show a saved plan
+/// let result = ShowCommand::new()
+///     .plan_file("tfplan")
+///     .execute(&tf)
+///     .await?;
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Debug, Clone, Default)]
+pub struct ShowCommand {
+    plan_file: Option<String>,
+    json: bool,
+    raw_args: Vec<String>,
+}
+
+impl ShowCommand {
+    /// Create a new show command.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            json: true,
+            ..Self::default()
+        }
+    }
+
+    /// Show a saved plan file instead of current state.
+    #[must_use]
+    pub fn plan_file(mut self, path: &str) -> Self {
+        self.plan_file = Some(path.to_string());
+        self
+    }
+
+    /// Disable JSON output.
+    #[must_use]
+    pub fn no_json(mut self) -> Self {
+        self.json = false;
+        self
+    }
+
+    /// Add a raw argument (escape hatch for unsupported options).
+    #[must_use]
+    pub fn arg(mut self, arg: impl Into<String>) -> Self {
+        self.raw_args.push(arg.into());
+        self
+    }
+}
+
+impl TerraformCommand for ShowCommand {
+    type Output = ShowResult;
+
+    fn args(&self) -> Vec<String> {
+        let mut args = vec!["show".to_string()];
+        if self.json {
+            args.push("-json".to_string());
+        }
+        args.extend(self.raw_args.clone());
+        // Plan file is a positional argument at the end
+        if let Some(ref plan) = self.plan_file {
+            args.push(plan.clone());
+        }
+        args
+    }
+
+    async fn execute(&self, tf: &Terraform) -> Result<ShowResult> {
+        let output = exec::run_terraform(tf, self.args()).await?;
+
+        if !self.json {
+            return Ok(ShowResult::Plain(output));
+        }
+
+        #[cfg(feature = "json")]
+        if self.plan_file.is_some() {
+            let plan: crate::types::plan::PlanRepresentation = serde_json::from_str(&output.stdout)
+                .map_err(|e| crate::error::Error::ParseError {
+                    message: format!("failed to parse plan json: {e}"),
+                })?;
+            return Ok(ShowResult::Plan(Box::new(plan)));
+        }
+
+        #[cfg(feature = "json")]
+        {
+            let state: crate::types::state::StateRepresentation =
+                serde_json::from_str(&output.stdout).map_err(|e| {
+                    crate::error::Error::ParseError {
+                        message: format!("failed to parse state json: {e}"),
+                    }
+                })?;
+            Ok(ShowResult::State(state))
+        }
+
+        #[cfg(not(feature = "json"))]
+        Ok(ShowResult::Plain(output))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_args_include_json() {
+        let cmd = ShowCommand::new();
+        assert_eq!(cmd.args(), vec!["show", "-json"]);
+    }
+
+    #[test]
+    fn plan_file_at_end() {
+        let cmd = ShowCommand::new().plan_file("tfplan");
+        assert_eq!(cmd.args(), vec!["show", "-json", "tfplan"]);
+    }
+
+    #[test]
+    fn no_json_args() {
+        let cmd = ShowCommand::new().no_json();
+        assert_eq!(cmd.args(), vec!["show"]);
+    }
+
+    #[test]
+    fn no_json_with_plan_file() {
+        let cmd = ShowCommand::new().no_json().plan_file("tfplan");
+        assert_eq!(cmd.args(), vec!["show", "tfplan"]);
+    }
+}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,3 +1,5 @@
 pub mod output;
+pub mod plan;
+pub mod state;
 pub mod validation;
 pub mod version;

--- a/src/types/output.rs
+++ b/src/types/output.rs
@@ -6,9 +6,14 @@ pub struct OutputValue {
     /// Whether the output is marked as sensitive.
     pub sensitive: bool,
     /// The Terraform type expression (as a JSON value).
-    #[serde(rename = "type")]
+    ///
+    /// May be absent in plan output for outputs whose type is not yet known.
+    #[serde(rename = "type", default)]
     pub output_type: serde_json::Value,
     /// The output value.
+    ///
+    /// May be absent in plan output for outputs whose value is not yet known.
+    #[serde(default)]
     pub value: serde_json::Value,
 }
 

--- a/src/types/plan.rs
+++ b/src/types/plan.rs
@@ -1,0 +1,217 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::types::output::OutputValue;
+use crate::types::state::{Module, StateRepresentation};
+
+/// Plan representation from `terraform show -json <planfile>`.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct PlanRepresentation {
+    /// Schema format version.
+    pub format_version: String,
+    /// Terraform version that created the plan.
+    pub terraform_version: String,
+    /// The planned values after apply.
+    pub planned_values: PlannedValues,
+    /// Changes to resources.
+    #[serde(default)]
+    pub resource_changes: Vec<ResourceChange>,
+    /// Changes to outputs.
+    #[serde(default)]
+    pub output_changes: HashMap<String, OutputChange>,
+    /// Prior state (if any).
+    pub prior_state: Option<StateRepresentation>,
+    /// Plan timestamp.
+    #[serde(default)]
+    pub timestamp: Option<String>,
+    /// Whether the plan can be applied.
+    #[serde(default)]
+    pub applyable: bool,
+    /// Whether the plan is complete.
+    #[serde(default)]
+    pub complete: bool,
+    /// Whether the plan errored.
+    #[serde(default)]
+    pub errored: bool,
+}
+
+/// Planned values after apply.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct PlannedValues {
+    /// Planned output values.
+    #[serde(default)]
+    pub outputs: HashMap<String, OutputValue>,
+    /// The planned root module.
+    pub root_module: Module,
+}
+
+/// A change to a single resource.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ResourceChange {
+    /// Resource address (e.g., "null_resource.example").
+    pub address: String,
+    /// Mode: "managed" or "data".
+    pub mode: String,
+    /// Resource type.
+    #[serde(rename = "type")]
+    pub resource_type: String,
+    /// Resource name.
+    pub name: String,
+    /// Provider name.
+    pub provider_name: String,
+    /// The change details.
+    pub change: Change,
+}
+
+/// Details of a resource or output change.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct Change {
+    /// Actions: "no-op", "create", "read", "update", "delete", or combinations.
+    pub actions: Vec<String>,
+    /// Values before the change.
+    #[serde(default)]
+    pub before: Value,
+    /// Values after the change.
+    #[serde(default)]
+    pub after: Value,
+    /// Which values are unknown after apply.
+    #[serde(default)]
+    pub after_unknown: Value,
+    /// Which before-values are sensitive.
+    #[serde(default)]
+    pub before_sensitive: Value,
+    /// Which after-values are sensitive.
+    #[serde(default)]
+    pub after_sensitive: Value,
+}
+
+/// A change to a single output.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct OutputChange {
+    /// Actions: "no-op", "create", "update", "delete".
+    pub actions: Vec<String>,
+    /// Value before the change.
+    #[serde(default)]
+    pub before: Value,
+    /// Value after the change.
+    #[serde(default)]
+    pub after: Value,
+    /// Whether after value is unknown.
+    #[serde(default)]
+    pub after_unknown: Value,
+    /// Whether before value is sensitive.
+    #[serde(default)]
+    pub before_sensitive: Value,
+    /// Whether after value is sensitive.
+    #[serde(default)]
+    pub after_sensitive: Value,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserialize_plan() {
+        let json = r#"{
+            "format_version": "1.2",
+            "terraform_version": "1.14.6",
+            "planned_values": {
+                "outputs": {
+                    "id": {
+                        "sensitive": false,
+                        "type": "string",
+                        "value": "123456"
+                    }
+                },
+                "root_module": {
+                    "resources": [
+                        {
+                            "address": "null_resource.example",
+                            "mode": "managed",
+                            "type": "null_resource",
+                            "name": "example",
+                            "provider_name": "registry.terraform.io/hashicorp/null",
+                            "schema_version": 0,
+                            "values": {"id": "123456"},
+                            "sensitive_values": {}
+                        }
+                    ]
+                }
+            },
+            "resource_changes": [
+                {
+                    "address": "null_resource.example",
+                    "mode": "managed",
+                    "type": "null_resource",
+                    "name": "example",
+                    "provider_name": "registry.terraform.io/hashicorp/null",
+                    "change": {
+                        "actions": ["no-op"],
+                        "before": {"id": "123456"},
+                        "after": {"id": "123456"},
+                        "after_unknown": {},
+                        "before_sensitive": {},
+                        "after_sensitive": {}
+                    }
+                }
+            ],
+            "output_changes": {
+                "id": {
+                    "actions": ["no-op"],
+                    "before": "123456",
+                    "after": "123456",
+                    "after_unknown": false,
+                    "before_sensitive": false,
+                    "after_sensitive": false
+                }
+            },
+            "applyable": false,
+            "complete": true,
+            "errored": false
+        }"#;
+        let plan: PlanRepresentation = serde_json::from_str(json).unwrap();
+        assert_eq!(plan.format_version, "1.2");
+        assert_eq!(plan.resource_changes.len(), 1);
+        assert_eq!(plan.resource_changes[0].change.actions, vec!["no-op"]);
+        assert_eq!(plan.output_changes.len(), 1);
+        assert!(!plan.applyable);
+        assert!(plan.complete);
+    }
+
+    #[test]
+    fn deserialize_plan_with_create() {
+        let json = r#"{
+            "format_version": "1.2",
+            "terraform_version": "1.14.6",
+            "planned_values": {
+                "root_module": { "resources": [] }
+            },
+            "resource_changes": [
+                {
+                    "address": "null_resource.new",
+                    "mode": "managed",
+                    "type": "null_resource",
+                    "name": "new",
+                    "provider_name": "registry.terraform.io/hashicorp/null",
+                    "change": {
+                        "actions": ["create"],
+                        "before": null,
+                        "after": {"triggers": null},
+                        "after_unknown": {"id": true},
+                        "before_sensitive": false,
+                        "after_sensitive": false
+                    }
+                }
+            ],
+            "applyable": true,
+            "complete": true,
+            "errored": false
+        }"#;
+        let plan: PlanRepresentation = serde_json::from_str(json).unwrap();
+        assert_eq!(plan.resource_changes[0].change.actions, vec!["create"]);
+        assert!(plan.applyable);
+    }
+}

--- a/src/types/state.rs
+++ b/src/types/state.rs
@@ -1,0 +1,136 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::types::output::OutputValue;
+
+/// State representation from `terraform show -json` (current state).
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct StateRepresentation {
+    /// Schema format version.
+    pub format_version: String,
+    /// Terraform version that wrote the state.
+    pub terraform_version: String,
+    /// The state values.
+    pub values: StateValues,
+}
+
+/// Top-level state values.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct StateValues {
+    /// Output values.
+    #[serde(default)]
+    pub outputs: HashMap<String, OutputValue>,
+    /// The root module.
+    pub root_module: Module,
+}
+
+/// A module in the state or plan. Contains resources and child modules.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct Module {
+    /// Resources in this module.
+    #[serde(default)]
+    pub resources: Vec<Resource>,
+    /// Child modules.
+    #[serde(default)]
+    pub child_modules: Vec<ChildModule>,
+}
+
+/// A child module reference.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ChildModule {
+    /// Module address (e.g., "module.vpc").
+    pub address: String,
+    /// Resources in this child module.
+    #[serde(default)]
+    pub resources: Vec<Resource>,
+    /// Nested child modules.
+    #[serde(default)]
+    pub child_modules: Vec<ChildModule>,
+}
+
+/// A resource in the state or plan.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct Resource {
+    /// Full address (e.g., "null_resource.example").
+    pub address: String,
+    /// Mode: "managed" or "data".
+    pub mode: String,
+    /// Resource type (e.g., "null_resource").
+    #[serde(rename = "type")]
+    pub resource_type: String,
+    /// Resource name (e.g., "example").
+    pub name: String,
+    /// Provider name (e.g., "registry.terraform.io/hashicorp/null").
+    pub provider_name: String,
+    /// Schema version.
+    pub schema_version: u32,
+    /// Resource attribute values.
+    #[serde(default)]
+    pub values: Value,
+    /// Which values are sensitive.
+    #[serde(default)]
+    pub sensitive_values: Value,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserialize_state() {
+        let json = r#"{
+            "format_version": "1.0",
+            "terraform_version": "1.14.6",
+            "values": {
+                "outputs": {
+                    "id": {
+                        "sensitive": false,
+                        "value": "123456",
+                        "type": "string"
+                    }
+                },
+                "root_module": {
+                    "resources": [
+                        {
+                            "address": "null_resource.example",
+                            "mode": "managed",
+                            "type": "null_resource",
+                            "name": "example",
+                            "provider_name": "registry.terraform.io/hashicorp/null",
+                            "schema_version": 0,
+                            "values": {"id": "123456", "triggers": {"value": "hello"}},
+                            "sensitive_values": {"triggers": {}}
+                        }
+                    ]
+                }
+            }
+        }"#;
+        let state: StateRepresentation = serde_json::from_str(json).unwrap();
+        assert_eq!(state.format_version, "1.0");
+        assert_eq!(state.values.outputs.len(), 1);
+        assert_eq!(state.values.root_module.resources.len(), 1);
+        assert_eq!(
+            state.values.root_module.resources[0].address,
+            "null_resource.example"
+        );
+        assert_eq!(state.values.root_module.resources[0].mode, "managed");
+    }
+
+    #[test]
+    fn deserialize_state_no_outputs() {
+        let json = r#"{
+            "format_version": "1.0",
+            "terraform_version": "1.14.6",
+            "values": {
+                "root_module": {
+                    "resources": []
+                }
+            }
+        }"#;
+        let state: StateRepresentation = serde_json::from_str(json).unwrap();
+        assert!(state.values.outputs.is_empty());
+        assert!(state.values.root_module.resources.is_empty());
+    }
+}

--- a/tests/lifecycle.rs
+++ b/tests/lifecycle.rs
@@ -3,6 +3,7 @@ use terraform_wrapper::commands::destroy::DestroyCommand;
 use terraform_wrapper::commands::init::InitCommand;
 use terraform_wrapper::commands::output::{OutputCommand, OutputResult};
 use terraform_wrapper::commands::plan::PlanCommand;
+use terraform_wrapper::commands::show::{ShowCommand, ShowResult};
 use terraform_wrapper::commands::validate::ValidateCommand;
 use terraform_wrapper::{Terraform, TerraformCommand};
 
@@ -215,4 +216,75 @@ output "bad" {
     assert!(!result.valid);
     assert!(result.error_count > 0);
     assert!(!result.diagnostics.is_empty());
+}
+
+#[tokio::test]
+async fn show_current_state() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+
+    let Some(tf) = setup_terraform(dir) else {
+        eprintln!("terraform not found, skipping test");
+        return;
+    };
+
+    write_null_config(dir);
+    InitCommand::new().execute(&tf).await.unwrap();
+    ApplyCommand::new()
+        .auto_approve()
+        .execute(&tf)
+        .await
+        .unwrap();
+
+    let result = ShowCommand::new().execute(&tf).await.unwrap();
+    match result {
+        ShowResult::State(state) => {
+            assert_eq!(state.format_version, "1.0");
+            assert!(!state.terraform_version.is_empty());
+            assert_eq!(state.values.root_module.resources.len(), 1);
+            assert_eq!(
+                state.values.root_module.resources[0].address,
+                "null_resource.example"
+            );
+            assert!(state.values.outputs.contains_key("trigger"));
+        }
+        _ => panic!("expected State variant"),
+    }
+
+    DestroyCommand::new()
+        .auto_approve()
+        .execute(&tf)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn show_saved_plan() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+
+    let Some(tf) = setup_terraform(dir) else {
+        eprintln!("terraform not found, skipping test");
+        return;
+    };
+
+    write_null_config(dir);
+    InitCommand::new().execute(&tf).await.unwrap();
+    PlanCommand::new().out("tfplan").execute(&tf).await.unwrap();
+
+    let result = ShowCommand::new()
+        .plan_file("tfplan")
+        .execute(&tf)
+        .await
+        .unwrap();
+    match result {
+        ShowResult::Plan(plan) => {
+            assert!(!plan.terraform_version.is_empty());
+            assert_eq!(plan.resource_changes.len(), 1);
+            assert_eq!(plan.resource_changes[0].address, "null_resource.example");
+            assert_eq!(plan.resource_changes[0].change.actions, vec!["create"]);
+            assert!(plan.applyable);
+        }
+        _ => panic!("expected Plan variant"),
+    }
 }


### PR DESCRIPTION
Closes #1

## Summary

- Add `ShowCommand` for inspecting current state (`ShowResult::State`) or saved plans (`ShowResult::Plan`)
- Add `StateRepresentation` and `PlanRepresentation` JSON types with shared `Module`/`Resource` structures
- Add `ResourceChange`, `OutputChange`, `Change` types for plan diffs
- Make `OutputValue.output_type` and `value` fields tolerant of absent values (plan outputs for unknown values omit these fields)

## Test plan

- [x] Unit tests for arg building (4 tests) and JSON deserialization (4 tests)
- [x] Integration tests: `show_current_state` and `show_saved_plan`
- [x] All 49 tests pass
- [x] clippy/fmt/doc clean