### PR TITLE
feat: add StateCommand and ImportCommand

### DIFF
--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -1,0 +1,150 @@
+use crate::Terraform;
+use crate::command::TerraformCommand;
+use crate::error::Result;
+use crate::exec::{self, CommandOutput};
+
+/// Command for importing existing infrastructure into Terraform state.
+///
+/// Associates an existing resource with a Terraform resource address.
+///
+/// ```no_run
+/// # async fn example() -> terraform_wrapper::error::Result<()> {
+/// use terraform_wrapper::{Terraform, TerraformCommand};
+/// use terraform_wrapper::commands::import::ImportCommand;
+///
+/// let tf = Terraform::builder().working_dir("/tmp/infra").build()?;
+/// ImportCommand::new("aws_instance.web", "i-1234567890abcdef0")
+///     .execute(&tf)
+///     .await?;
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Debug, Clone)]
+pub struct ImportCommand {
+    address: String,
+    id: String,
+    vars: Vec<(String, String)>,
+    var_files: Vec<String>,
+    lock: Option<bool>,
+    lock_timeout: Option<String>,
+    raw_args: Vec<String>,
+}
+
+impl ImportCommand {
+    /// Create a new import command.
+    ///
+    /// - `address`: The Terraform resource address (e.g., "aws_instance.web")
+    /// - `id`: The provider-specific resource ID (e.g., "i-1234567890abcdef0")
+    #[must_use]
+    pub fn new(address: &str, id: &str) -> Self {
+        Self {
+            address: address.to_string(),
+            id: id.to_string(),
+            vars: Vec::new(),
+            var_files: Vec::new(),
+            lock: None,
+            lock_timeout: None,
+            raw_args: Vec::new(),
+        }
+    }
+
+    /// Set a variable value (`-var="name=value"`).
+    #[must_use]
+    pub fn var(mut self, name: &str, value: &str) -> Self {
+        self.vars.push((name.to_string(), value.to_string()));
+        self
+    }
+
+    /// Add a variable definitions file (`-var-file`).
+    #[must_use]
+    pub fn var_file(mut self, path: &str) -> Self {
+        self.var_files.push(path.to_string());
+        self
+    }
+
+    /// Enable or disable state locking (`-lock`).
+    #[must_use]
+    pub fn lock(mut self, enabled: bool) -> Self {
+        self.lock = Some(enabled);
+        self
+    }
+
+    /// Duration to wait for state lock (`-lock-timeout`).
+    #[must_use]
+    pub fn lock_timeout(mut self, timeout: &str) -> Self {
+        self.lock_timeout = Some(timeout.to_string());
+        self
+    }
+
+    /// Add a raw argument (escape hatch for unsupported options).
+    #[must_use]
+    pub fn arg(mut self, arg: impl Into<String>) -> Self {
+        self.raw_args.push(arg.into());
+        self
+    }
+}
+
+impl TerraformCommand for ImportCommand {
+    type Output = CommandOutput;
+
+    fn args(&self) -> Vec<String> {
+        let mut args = vec!["import".to_string()];
+        for (name, value) in &self.vars {
+            args.push(format!("-var={name}={value}"));
+        }
+        for file in &self.var_files {
+            args.push(format!("-var-file={file}"));
+        }
+        if let Some(lock) = self.lock {
+            args.push(format!("-lock={lock}"));
+        }
+        if let Some(ref timeout) = self.lock_timeout {
+            args.push(format!("-lock-timeout={timeout}"));
+        }
+        args.extend(self.raw_args.clone());
+        // Positional args at end: address, then id
+        args.push(self.address.clone());
+        args.push(self.id.clone());
+        args
+    }
+
+    async fn execute(&self, tf: &Terraform) -> Result<CommandOutput> {
+        let mut args = self.args();
+        if tf.no_input {
+            args.insert(1, "-input=false".to_string());
+        }
+        exec::run_terraform(tf, args).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn basic_args() {
+        let cmd = ImportCommand::new("aws_instance.web", "i-123");
+        assert_eq!(cmd.args(), vec!["import", "aws_instance.web", "i-123"]);
+    }
+
+    #[test]
+    fn with_vars() {
+        let cmd = ImportCommand::new("aws_instance.web", "i-123").var("region", "us-west-2");
+        let args = cmd.args();
+        assert!(args.contains(&"-var=region=us-west-2".to_string()));
+        // Positional args still at end
+        let len = args.len();
+        assert_eq!(args[len - 2], "aws_instance.web");
+        assert_eq!(args[len - 1], "i-123");
+    }
+
+    #[test]
+    fn with_lock_options() {
+        let cmd = ImportCommand::new("aws_instance.web", "i-123")
+            .lock(false)
+            .lock_timeout("10s");
+        let args = cmd.args();
+        assert!(args.contains(&"-lock=false".to_string()));
+        assert!(args.contains(&"-lock-timeout=10s".to_string()));
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,7 +1,9 @@
 pub mod apply;
 pub mod destroy;
+pub mod import;
 pub mod init;
 pub mod output;
 pub mod plan;
+pub mod state;
 pub mod validate;
 pub mod version;

--- a/src/commands/state.rs
+++ b/src/commands/state.rs
@@ -1,0 +1,202 @@
+use crate::Terraform;
+use crate::command::TerraformCommand;
+use crate::error::Result;
+use crate::exec::{self, CommandOutput};
+
+/// The state subcommand to execute.
+#[derive(Debug, Clone)]
+pub enum StateSubcommand {
+    /// List resources in the state.
+    List,
+    /// Show a single resource in the state.
+    Show(String),
+    /// Move a resource to a different address.
+    Mv {
+        /// Source address.
+        source: String,
+        /// Destination address.
+        destination: String,
+    },
+    /// Remove a resource from the state (without destroying it).
+    Rm(Vec<String>),
+    /// Pull remote state and output to stdout.
+    Pull,
+    /// Push local state to remote backend.
+    Push,
+}
+
+/// Command for managing Terraform state.
+///
+/// ```no_run
+/// # async fn example() -> terraform_wrapper::error::Result<()> {
+/// use terraform_wrapper::{Terraform, TerraformCommand};
+/// use terraform_wrapper::commands::state::StateCommand;
+///
+/// let tf = Terraform::builder().working_dir("/tmp/infra").build()?;
+///
+/// // List resources in state
+/// let output = StateCommand::list().execute(&tf).await?;
+///
+/// // Show a specific resource
+/// let output = StateCommand::show("null_resource.example")
+///     .execute(&tf)
+///     .await?;
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Debug, Clone)]
+pub struct StateCommand {
+    subcommand: StateSubcommand,
+    raw_args: Vec<String>,
+}
+
+impl StateCommand {
+    /// List resources in the state.
+    #[must_use]
+    pub fn list() -> Self {
+        Self {
+            subcommand: StateSubcommand::List,
+            raw_args: Vec::new(),
+        }
+    }
+
+    /// Show a single resource in the state.
+    #[must_use]
+    pub fn show(address: &str) -> Self {
+        Self {
+            subcommand: StateSubcommand::Show(address.to_string()),
+            raw_args: Vec::new(),
+        }
+    }
+
+    /// Move a resource to a different address.
+    #[must_use]
+    pub fn mv(source: &str, destination: &str) -> Self {
+        Self {
+            subcommand: StateSubcommand::Mv {
+                source: source.to_string(),
+                destination: destination.to_string(),
+            },
+            raw_args: Vec::new(),
+        }
+    }
+
+    /// Remove resources from the state (without destroying them).
+    #[must_use]
+    pub fn rm(addresses: Vec<String>) -> Self {
+        Self {
+            subcommand: StateSubcommand::Rm(addresses),
+            raw_args: Vec::new(),
+        }
+    }
+
+    /// Pull remote state and output to stdout.
+    #[must_use]
+    pub fn pull() -> Self {
+        Self {
+            subcommand: StateSubcommand::Pull,
+            raw_args: Vec::new(),
+        }
+    }
+
+    /// Push local state to remote backend.
+    #[must_use]
+    pub fn push() -> Self {
+        Self {
+            subcommand: StateSubcommand::Push,
+            raw_args: Vec::new(),
+        }
+    }
+
+    /// Add a raw argument (escape hatch for unsupported options).
+    #[must_use]
+    pub fn arg(mut self, arg: impl Into<String>) -> Self {
+        self.raw_args.push(arg.into());
+        self
+    }
+}
+
+impl TerraformCommand for StateCommand {
+    type Output = CommandOutput;
+
+    fn args(&self) -> Vec<String> {
+        let mut args = vec!["state".to_string()];
+        match &self.subcommand {
+            StateSubcommand::List => args.push("list".to_string()),
+            StateSubcommand::Show(address) => {
+                args.push("show".to_string());
+                args.push(address.clone());
+            }
+            StateSubcommand::Mv {
+                source,
+                destination,
+            } => {
+                args.push("mv".to_string());
+                args.push(source.clone());
+                args.push(destination.clone());
+            }
+            StateSubcommand::Rm(addresses) => {
+                args.push("rm".to_string());
+                args.extend(addresses.clone());
+            }
+            StateSubcommand::Pull => args.push("pull".to_string()),
+            StateSubcommand::Push => args.push("push".to_string()),
+        }
+        args.extend(self.raw_args.clone());
+        args
+    }
+
+    async fn execute(&self, tf: &Terraform) -> Result<CommandOutput> {
+        exec::run_terraform(tf, self.args()).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn list_args() {
+        let cmd = StateCommand::list();
+        assert_eq!(cmd.args(), vec!["state", "list"]);
+    }
+
+    #[test]
+    fn show_args() {
+        let cmd = StateCommand::show("null_resource.example");
+        assert_eq!(cmd.args(), vec!["state", "show", "null_resource.example"]);
+    }
+
+    #[test]
+    fn mv_args() {
+        let cmd = StateCommand::mv("null_resource.old", "null_resource.new");
+        assert_eq!(
+            cmd.args(),
+            vec!["state", "mv", "null_resource.old", "null_resource.new"]
+        );
+    }
+
+    #[test]
+    fn rm_args() {
+        let cmd = StateCommand::rm(vec![
+            "null_resource.a".to_string(),
+            "null_resource.b".to_string(),
+        ]);
+        assert_eq!(
+            cmd.args(),
+            vec!["state", "rm", "null_resource.a", "null_resource.b"]
+        );
+    }
+
+    #[test]
+    fn pull_args() {
+        let cmd = StateCommand::pull();
+        assert_eq!(cmd.args(), vec!["state", "pull"]);
+    }
+
+    #[test]
+    fn push_args() {
+        let cmd = StateCommand::push();
+        assert_eq!(cmd.args(), vec!["state", "push"]);
+    }
+}

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -63,18 +63,14 @@ async fn run_terraform_inner(
         cmd.arg(format!("-chdir={}", working_dir.display()));
     }
 
-    // Subcommand name comes first (e.g., "init", "plan", "apply")
-    if let Some(subcommand) = command_args.first() {
-        cmd.arg(subcommand);
-    }
-
-    // Global args (-no-color, -input=false) are per-subcommand flags
-    for arg in &tf.global_args {
+    // Command args (subcommand name + flags)
+    for arg in &command_args {
         cmd.arg(arg);
     }
 
-    // Remaining command-specific args
-    for arg in command_args.iter().skip(1) {
+    // Global args (-no-color) at the end, after all command args.
+    // This handles compound commands like "workspace show" and "state list".
+    for arg in &tf.global_args {
         cmd.arg(arg);
     }
 

--- a/tests/lifecycle.rs
+++ b/tests/lifecycle.rs
@@ -3,6 +3,7 @@ use terraform_wrapper::commands::destroy::DestroyCommand;
 use terraform_wrapper::commands::init::InitCommand;
 use terraform_wrapper::commands::output::{OutputCommand, OutputResult};
 use terraform_wrapper::commands::plan::PlanCommand;
+use terraform_wrapper::commands::state::StateCommand;
 use terraform_wrapper::commands::validate::ValidateCommand;
 use terraform_wrapper::{Terraform, TerraformCommand};
 
@@ -215,4 +216,40 @@ output "bad" {
     assert!(!result.valid);
     assert!(result.error_count > 0);
     assert!(!result.diagnostics.is_empty());
+}
+
+#[tokio::test]
+async fn state_list_and_show() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+
+    let Some(tf) = setup_terraform(dir) else {
+        eprintln!("terraform not found, skipping test");
+        return;
+    };
+
+    write_null_config(dir);
+    InitCommand::new().execute(&tf).await.unwrap();
+    ApplyCommand::new()
+        .auto_approve()
+        .execute(&tf)
+        .await
+        .unwrap();
+
+    // List should include our resource
+    let output = StateCommand::list().execute(&tf).await.unwrap();
+    assert!(output.stdout.contains("null_resource.example"));
+
+    // Show should include resource details
+    let output = StateCommand::show("null_resource.example")
+        .execute(&tf)
+        .await
+        .unwrap();
+    assert!(output.stdout.contains("null_resource.example"));
+
+    DestroyCommand::new()
+        .auto_approve()
+        .execute(&tf)
+        .await
+        .unwrap();
 }


### PR DESCRIPTION
Closes #4
Closes #5

## Summary

- Add `StateCommand` with `list`, `show`, `mv`, `rm`, `pull`, `push` subcommands
- Add `ImportCommand` with `var`, `var-file`, `lock` options
- Fix global args placement in exec engine (same compound command fix as workspace PR)

## Test plan

- [x] Unit tests: 6 state arg tests + 3 import arg tests
- [x] Integration test: `state_list_and_show` (apply, list, show, destroy)
- [x] All 57 tests pass
- [x] clippy/fmt/doc clean