### PR TITLE
feat: add GCP Compute Engine example

### DIFF
--- a/examples/gce-instance/main.tf
+++ b/examples/gce-instance/main.tf
@@ -1,0 +1,40 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project
+  region  = var.region
+  zone    = var.zone
+}
+
+resource "google_compute_network" "example" {
+  name                    = "${var.instance_name}-network"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "example" {
+  name          = "${var.instance_name}-subnet"
+  ip_cidr_range = "10.0.1.0/24"
+  network       = google_compute_network.example.id
+}
+
+resource "google_compute_instance" "example" {
+  name         = var.instance_name
+  machine_type = var.machine_type
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-12"
+    }
+  }
+
+  network_interface {
+    subnetwork = google_compute_subnetwork.example.id
+  }
+}

--- a/examples/gce-instance/outputs.tf
+++ b/examples/gce-instance/outputs.tf
@@ -1,0 +1,19 @@
+output "instance_id" {
+  description = "ID of the GCE instance"
+  value       = google_compute_instance.example.instance_id
+}
+
+output "internal_ip" {
+  description = "Internal IP address of the instance"
+  value       = google_compute_instance.example.network_interface[0].network_ip
+}
+
+output "network_id" {
+  description = "Network ID"
+  value       = google_compute_network.example.id
+}
+
+output "subnet_id" {
+  description = "Subnet ID"
+  value       = google_compute_subnetwork.example.id
+}

--- a/examples/gce-instance/variables.tf
+++ b/examples/gce-instance/variables.tf
@@ -1,0 +1,28 @@
+variable "project" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region"
+  type        = string
+  default     = "us-central1"
+}
+
+variable "zone" {
+  description = "GCP zone"
+  type        = string
+  default     = "us-central1-a"
+}
+
+variable "machine_type" {
+  description = "GCE machine type"
+  type        = string
+  default     = "e2-micro"
+}
+
+variable "instance_name" {
+  description = "Name for the instance"
+  type        = string
+  default     = "terraform-wrapper-example"
+}

--- a/examples/gce_instance.rs
+++ b/examples/gce_instance.rs
@@ -1,0 +1,87 @@
+//! Basic GCE instance lifecycle: init, plan, apply, read outputs, destroy.
+//!
+//! Requires:
+//! - GCP Application Default Credentials (`gcloud auth application-default login`)
+//! - A GCP project with Compute Engine API enabled
+//!
+//! Usage:
+//!   cargo run --example gce_instance -- --project=YOUR_PROJECT_ID
+//!
+//! To tear down only:
+//!   cargo run --example gce_instance -- --project=YOUR_PROJECT_ID --destroy
+
+use terraform_wrapper::commands::apply::ApplyCommand;
+use terraform_wrapper::commands::destroy::DestroyCommand;
+use terraform_wrapper::commands::init::InitCommand;
+use terraform_wrapper::commands::output::{OutputCommand, OutputResult};
+use terraform_wrapper::commands::plan::PlanCommand;
+use terraform_wrapper::{Terraform, TerraformCommand};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<String> = std::env::args().collect();
+
+    let project = args
+        .iter()
+        .find(|a| a.starts_with("--project="))
+        .map(|a| a.trim_start_matches("--project=").to_string())
+        .expect("Usage: cargo run --example gce_instance -- --project=YOUR_PROJECT_ID");
+
+    let destroy_only = args.iter().any(|a| a == "--destroy");
+
+    let tf = Terraform::builder()
+        .working_dir("examples/gce-instance")
+        .build()?;
+
+    let version = tf.version().await?;
+    println!("Terraform {}", version.terraform_version);
+
+    if destroy_only {
+        println!("\n--- Destroying infrastructure ---");
+        DestroyCommand::new()
+            .auto_approve()
+            .var("project", &project)
+            .execute(&tf)
+            .await?;
+        println!("Destroyed.");
+        return Ok(());
+    }
+
+    // Init
+    println!("\n--- Initializing ---");
+    InitCommand::new().execute(&tf).await?;
+    println!("Initialized.");
+
+    // Plan
+    println!("\n--- Planning ---");
+    let plan_output = PlanCommand::new()
+        .var("project", &project)
+        .out("tfplan")
+        .detailed_exitcode()
+        .execute(&tf)
+        .await?;
+
+    if plan_output.exit_code == 0 {
+        println!("No changes needed.");
+        return Ok(());
+    }
+    println!("Changes detected.");
+
+    // Apply
+    println!("\n--- Applying ---");
+    ApplyCommand::new().plan_file("tfplan").execute(&tf).await?;
+    println!("Applied.");
+
+    // Read outputs
+    println!("\n--- Outputs ---");
+    let result = OutputCommand::new().json().execute(&tf).await?;
+    if let OutputResult::Json(outputs) = result {
+        for (name, val) in &outputs {
+            println!("  {name} = {}", val.value);
+        }
+    }
+
+    println!("\nTo destroy: cargo run --example gce_instance -- --project={project} --destroy");
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- Add GCE instance example mirroring the EC2 example
- Creates VPC, subnet, and e2-micro instance in GCP
- Requires `--project` flag and Application Default Credentials
- Tested: full lifecycle (init, plan, apply, outputs, destroy) against `terraform-wrapper-demo` project

## Test plan

- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] Manual test: full lifecycle against live GCP project