### PR TITLE
feat: add re-exports and prelude module for ergonomic imports

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -10,3 +10,20 @@ pub mod state;
 pub mod validate;
 pub mod version;
 pub mod workspace;
+
+// Re-export command types for ergonomic imports.
+//
+// Allows: `use terraform_wrapper::commands::{InitCommand, ApplyCommand};`
+// Instead of: `use terraform_wrapper::commands::init::InitCommand;`
+pub use apply::ApplyCommand;
+pub use destroy::DestroyCommand;
+pub use fmt::FmtCommand;
+pub use import::ImportCommand;
+pub use init::InitCommand;
+pub use output::{OutputCommand, OutputResult};
+pub use plan::PlanCommand;
+pub use show::{ShowCommand, ShowResult};
+pub use state::StateCommand;
+pub use validate::ValidateCommand;
+pub use version::VersionCommand;
+pub use workspace::WorkspaceCommand;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,10 +7,7 @@
 //! # Quick Start
 //!
 //! ```no_run
-//! use terraform_wrapper::{Terraform, TerraformCommand};
-//! use terraform_wrapper::commands::init::InitCommand;
-//! use terraform_wrapper::commands::apply::ApplyCommand;
-//! use terraform_wrapper::commands::output::{OutputCommand, OutputResult};
+//! use terraform_wrapper::prelude::*;
 //!
 //! # async fn example() -> terraform_wrapper::error::Result<()> {
 //! let tf = Terraform::builder()
@@ -33,6 +30,24 @@
 //! # Ok(())
 //! # }
 //! ```
+//!
+//! # Imports
+//!
+//! The [`prelude`] module re-exports everything you need:
+//!
+//! ```rust
+//! use terraform_wrapper::prelude::*;
+//! ```
+//!
+//! Or import selectively from [`commands`]:
+//!
+//! ```rust
+//! use terraform_wrapper::{Terraform, TerraformCommand};
+//! use terraform_wrapper::commands::{InitCommand, ApplyCommand, OutputCommand, OutputResult};
+//! ```
+//!
+//! Note: You must import [`TerraformCommand`] (via prelude or directly) to call
+//! `.execute()` on any command.
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -41,6 +56,7 @@ pub mod command;
 pub mod commands;
 pub mod error;
 pub mod exec;
+pub mod prelude;
 #[cfg(feature = "json")]
 pub mod types;
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,0 +1,17 @@
+//! Convenience re-exports for common usage.
+//!
+//! ```rust
+//! use terraform_wrapper::prelude::*;
+//! ```
+//!
+//! This imports the [`Terraform`] client, [`TerraformCommand`] trait (required
+//! for `.execute()`), all command types, result enums, and [`CommandOutput`].
+
+pub use crate::Terraform;
+pub use crate::command::TerraformCommand;
+pub use crate::commands::{
+    ApplyCommand, DestroyCommand, FmtCommand, ImportCommand, InitCommand, OutputCommand,
+    OutputResult, PlanCommand, ShowCommand, ShowResult, StateCommand, ValidateCommand,
+    VersionCommand, WorkspaceCommand,
+};
+pub use crate::exec::CommandOutput;


### PR DESCRIPTION
Closes #32

## Summary

Addresses all three ergonomic issues from first real-world consumer feedback:

**1. Command re-exports from `commands` module**

Before:
```rust
use terraform_wrapper::commands::init::InitCommand;
use terraform_wrapper::commands::apply::ApplyCommand;
```

After:
```rust
use terraform_wrapper::commands::{InitCommand, ApplyCommand};
```

**2. Prelude module**

```rust
use terraform_wrapper::prelude::*;
// Imports Terraform, TerraformCommand, all commands, OutputResult, ShowResult, CommandOutput
```

**3. anyhow compatibility**

The `Error` type already implements `std::error::Error` via thiserror, so `?` works directly with `anyhow::Result`. The `map_err` type inference issue is a Rust limitation -- documented in commit message.

## Test plan

- [x] 86 tests pass (57 unit + 11 integration + 2 version + 16 doc)
- [x] clippy/fmt clean
- [x] New doc examples compile (prelude import, selective import)