### PR TITLE
feat: add command timeout support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default = ["json"]
 json = ["serde", "serde_json"]
 
 [dependencies]
-tokio = { version = "1", features = ["process", "rt-multi-thread", "macros", "io-util"] }
+tokio = { version = "1", features = ["process", "rt-multi-thread", "macros", "io-util", "time"] }
 thiserror = "2.0"
 tracing = "0.1"
 which = "8.0"
@@ -28,6 +28,6 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0", optional = true }
 
 [dev-dependencies]
-tokio = { version = "1", features = ["process", "rt-multi-thread", "macros", "io-util"] }
+tokio = { version = "1", features = ["process", "rt-multi-thread", "macros", "io-util", "time"] }
 serde_json = "1.0"
 tempfile = "3.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -40,6 +40,13 @@ pub enum Error {
         source: std::io::Error,
     },
 
+    /// Command execution timed out.
+    #[error("terraform command timed out after {timeout_seconds}s")]
+    Timeout {
+        /// The timeout duration in seconds.
+        timeout_seconds: u64,
+    },
+
     /// JSON deserialization error.
     #[cfg(feature = "json")]
     #[error("json parse error: {message}")]

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -1,7 +1,7 @@
 use std::process::Stdio;
 
 use tokio::process::Command as TokioCommand;
-use tracing::{debug, trace};
+use tracing::{debug, trace, warn};
 
 use crate::Terraform;
 use crate::error::{Error, Result};
@@ -35,8 +35,10 @@ impl CommandOutput {
 /// Note: `-chdir` is the only true global option (before the subcommand).
 /// Options like `-no-color` and `-input=false` are per-subcommand flags
 /// and are placed after the subcommand name.
+///
+/// Uses the client's default timeout if set.
 pub async fn run_terraform(tf: &Terraform, command_args: Vec<String>) -> Result<CommandOutput> {
-    run_terraform_inner(tf, command_args, &[0]).await
+    run_terraform_inner(tf, command_args, &[0], tf.timeout).await
 }
 
 /// Execute a Terraform command, accepting additional exit codes as success.
@@ -48,13 +50,25 @@ pub async fn run_terraform_allow_exit_codes(
     command_args: Vec<String>,
     allowed_codes: &[i32],
 ) -> Result<CommandOutput> {
-    run_terraform_inner(tf, command_args, allowed_codes).await
+    run_terraform_inner(tf, command_args, allowed_codes, tf.timeout).await
+}
+
+/// Execute a Terraform command with a specific timeout override.
+///
+/// The provided timeout takes precedence over the client's default.
+pub async fn run_terraform_with_timeout(
+    tf: &Terraform,
+    command_args: Vec<String>,
+    timeout: std::time::Duration,
+) -> Result<CommandOutput> {
+    run_terraform_inner(tf, command_args, &[0], Some(timeout)).await
 }
 
 async fn run_terraform_inner(
     tf: &Terraform,
     command_args: Vec<String>,
     allowed_codes: &[i32],
+    timeout: Option<std::time::Duration>,
 ) -> Result<CommandOutput> {
     let mut cmd = TokioCommand::new(&tf.binary);
 
@@ -82,9 +96,26 @@ async fn run_terraform_inner(
     cmd.stdout(Stdio::piped());
     cmd.stderr(Stdio::piped());
 
-    trace!(binary = ?tf.binary, args = ?command_args, "executing terraform command");
+    trace!(binary = ?tf.binary, args = ?command_args, timeout_secs = ?timeout.map(|t| t.as_secs()), "executing terraform command");
 
-    let output = cmd.output().await.map_err(|e| {
+    let io_result = if let Some(duration) = timeout {
+        match tokio::time::timeout(duration, cmd.output()).await {
+            Ok(result) => result,
+            Err(_) => {
+                warn!(
+                    timeout_seconds = duration.as_secs(),
+                    "terraform command timed out"
+                );
+                return Err(Error::Timeout {
+                    timeout_seconds: duration.as_secs(),
+                });
+            }
+        }
+    } else {
+        cmd.output().await
+    };
+
+    let output = io_result.map_err(|e| {
         if e.kind() == std::io::ErrorKind::NotFound {
             Error::NotFound
         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,7 @@
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 pub mod command;
 pub mod commands;
@@ -78,6 +79,8 @@ pub struct Terraform {
     pub(crate) global_args: Vec<String>,
     /// Whether to add `-input=false` to commands that support it.
     pub(crate) no_input: bool,
+    /// Default timeout for command execution.
+    pub(crate) timeout: Option<Duration>,
 }
 
 impl Terraform {
@@ -107,6 +110,7 @@ pub struct TerraformBuilder {
     env: HashMap<String, String>,
     no_color: bool,
     input: bool,
+    timeout: Option<Duration>,
 }
 
 impl TerraformBuilder {
@@ -117,6 +121,7 @@ impl TerraformBuilder {
             env: HashMap::new(),
             no_color: true,
             input: false,
+            timeout: None,
         }
     }
 
@@ -165,6 +170,23 @@ impl TerraformBuilder {
         self
     }
 
+    /// Set a default timeout for all command executions.
+    ///
+    /// Commands that exceed this duration will be terminated and return
+    /// [`Error::Timeout`]. No timeout is set by default.
+    #[must_use]
+    pub fn timeout(mut self, duration: Duration) -> Self {
+        self.timeout = Some(duration);
+        self
+    }
+
+    /// Set a default timeout in seconds for all command executions.
+    #[must_use]
+    pub fn timeout_secs(mut self, seconds: u64) -> Self {
+        self.timeout = Some(Duration::from_secs(seconds));
+        self
+    }
+
     /// Build the [`Terraform`] client.
     ///
     /// Resolves the terraform binary in this order:
@@ -193,6 +215,7 @@ impl TerraformBuilder {
             env: self.env,
             global_args,
             no_input: !self.input,
+            timeout: self.timeout,
         })
     }
 }

--- a/tests/lifecycle.rs
+++ b/tests/lifecycle.rs
@@ -397,3 +397,32 @@ async fn state_list_and_show() {
         .await
         .unwrap();
 }
+
+#[tokio::test]
+async fn timeout_triggers_error() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+
+    // Build client with an impossibly short timeout
+    let tf = match Terraform::builder()
+        .working_dir(dir)
+        .timeout(std::time::Duration::from_nanos(1))
+        .build()
+    {
+        Ok(tf) => tf,
+        Err(_) => {
+            eprintln!("terraform not found, skipping test");
+            return;
+        }
+    };
+
+    write_null_config(dir);
+
+    let result = InitCommand::new().execute(&tf).await;
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(
+        matches!(err, terraform_wrapper::Error::Timeout { .. }),
+        "expected Timeout error, got: {err:?}"
+    );
+}


### PR DESCRIPTION
Closes #28

## Summary

- Add `Error::Timeout` variant with `timeout_seconds` field
- Add `timeout()` / `timeout_secs()` to `TerraformBuilder` for default client-wide timeout
- Wire timeout through exec engine using `tokio::time::timeout`
- Add `run_terraform_with_timeout()` for per-command override
- Add `tokio` `time` feature to dependencies

```rust
// Client-wide timeout
let tf = Terraform::builder()
    .working_dir("./infra")
    .timeout_secs(300)
    .build()?;

// Per-command override via exec
exec::run_terraform_with_timeout(&tf, args, Duration::from_secs(60)).await?;
```

## Test plan

- [x] 87 tests pass
- [x] Integration test: 1ns timeout triggers `Error::Timeout`
- [x] clippy/fmt/doc clean