### PR TITLE
feat: add per-command working directory override

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -288,6 +288,31 @@ impl Terraform {
     pub async fn version(&self) -> Result<types::version::VersionInfo> {
         commands::version::VersionCommand::new().execute(self).await
     }
+
+    /// Create a clone of this client with a different working directory.
+    ///
+    /// Useful for running a single command against a different directory
+    /// without modifying the original client:
+    ///
+    /// ```rust,no_run
+    /// # use terraform_wrapper::prelude::*;
+    /// # async fn example() -> terraform_wrapper::error::Result<()> {
+    /// let tf = Terraform::builder()
+    ///     .working_dir("./infra/network")
+    ///     .build()?;
+    ///
+    /// // Run one command against a different directory
+    /// let compute = tf.with_working_dir("./infra/compute");
+    /// InitCommand::new().execute(&compute).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[must_use]
+    pub fn with_working_dir(&self, path: impl AsRef<Path>) -> Self {
+        let mut clone = self.clone();
+        clone.working_dir = Some(path.as_ref().to_path_buf());
+        clone
+    }
 }
 
 /// Builder for constructing a [`Terraform`] client.

--- a/tests/lifecycle.rs
+++ b/tests/lifecycle.rs
@@ -426,3 +426,26 @@ async fn timeout_triggers_error() {
         "expected Timeout error, got: {err:?}"
     );
 }
+
+#[tokio::test]
+async fn with_working_dir_override() {
+    let tmp1 = tempfile::tempdir().unwrap();
+    let tmp2 = tempfile::tempdir().unwrap();
+
+    let Some(tf) = setup_terraform(tmp1.path()) else {
+        eprintln!("terraform not found, skipping test");
+        return;
+    };
+
+    // Write config only in the second directory
+    write_null_config(tmp2.path());
+
+    // Init should fail on tmp1 (no config), but succeed on tmp2 via override
+    let tf2 = tf.with_working_dir(tmp2.path());
+    let output = InitCommand::new().execute(&tf2).await.unwrap();
+    assert!(output.success);
+
+    // Validate the override worked by checking the original is unchanged
+    let result = ValidateCommand::new().no_json().execute(&tf).await;
+    assert!(result.is_err()); // No config in tmp1
+}


### PR DESCRIPTION
Closes #27

## Summary

Add `Terraform::with_working_dir()` which returns a clone of the client with a different working directory. No trait changes, no duplication -- works with any command.

```rust
let tf = Terraform::builder()
    .working_dir("./infra/network")
    .build()?;

// Run one command against a different directory
let compute = tf.with_working_dir("./infra/compute");
InitCommand::new().execute(&compute).await?;
```

## Test plan

- [x] 98 tests pass
- [x] Integration test: override works, original client unchanged
- [x] clippy/fmt/doc clean