### PR TITLE
docs: add documentation link to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ authors = ["Josh Rotenberg <joshrotenberg@gmail.com>"]
 description = "A type-safe Terraform CLI wrapper for Rust"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/joshrotenberg/terraform-wrapper"
+documentation = "https://docs.rs/terraform-wrapper"
 keywords = ["terraform", "infrastructure", "iac", "cli", "wrapper"]
 categories = ["development-tools", "api-bindings"]
 


### PR DESCRIPTION
## Summary
- Add `documentation` field pointing to https://docs.rs/terraform-wrapper in Cargo.toml

## Test plan
- [ ] Verify `cargo publish --dry-run` succeeds with the new field