### PR TITLE
fix: add timeout and configurable exit codes to stream_terraform

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ use terraform_wrapper::streaming::{stream_terraform, JsonLogLine};
 let result = stream_terraform(
     &tf,
     ApplyCommand::new().auto_approve().json(),
+    &[0],
     |line: JsonLogLine| {
         println!("[{}] {}", line.log_type, line.message);
     },

--- a/examples/streaming_apply.rs
+++ b/examples/streaming_apply.rs
@@ -39,6 +39,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let result = stream_terraform(
         &tf,
         ApplyCommand::new().auto_approve().json(),
+        &[0],
         |line: JsonLogLine| match line.log_type.as_str() {
             "version" => println!("  Terraform {}", line.message),
             "planned_change" => println!("  PLAN: {}", line.message),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,6 +222,7 @@
 //! let result = stream_terraform(
 //!     &tf,
 //!     ApplyCommand::new().auto_approve().json(),
+//!     &[0],
 //!     |line: JsonLogLine| {
 //!         match line.log_type.as_str() {
 //!             "apply_start" => println!("Creating: {}", line.message),

--- a/src/streaming.rs
+++ b/src/streaming.rs
@@ -15,7 +15,7 @@
 //! # async fn example() -> terraform_wrapper::error::Result<()> {
 //! let tf = Terraform::builder().working_dir("./infra").build()?;
 //!
-//! let result = stream_terraform(&tf, ApplyCommand::new().auto_approve().json(), |line| {
+//! let result = stream_terraform(&tf, ApplyCommand::new().auto_approve().json(), &[0], |line| {
 //!     println!("[{}] {}", line.log_type, line.message);
 //! }).await?;
 //!
@@ -79,6 +79,13 @@ pub struct JsonLogLine {
 /// as it arrives on stdout. Lines that fail to parse as JSON are logged and
 /// skipped.
 ///
+/// `allowed_exit_codes` controls which exit codes are treated as success.
+/// Pass `&[0]` for most commands, or `&[0, 2]` for `plan -detailed-exitcode`
+/// where exit code 2 means "changes present".
+///
+/// Respects the client's timeout setting. If the command exceeds the timeout,
+/// the child process is killed and [`Error::Timeout`] is returned.
+///
 /// Returns a [`CommandOutput`] with the complete stderr and exit code after
 /// the process finishes. Stdout is empty since lines were consumed by the
 /// handler.
@@ -88,6 +95,7 @@ pub struct JsonLogLine {
 pub async fn stream_terraform<C, F>(
     tf: &Terraform,
     command: C,
+    allowed_exit_codes: &[i32],
     mut handler: F,
 ) -> Result<CommandOutput>
 where
@@ -126,7 +134,7 @@ where
     cmd.stdout(Stdio::piped());
     cmd.stderr(Stdio::piped());
 
-    trace!(binary = ?tf.binary, args = ?args, "streaming terraform command");
+    trace!(binary = ?tf.binary, args = ?args, timeout_secs = ?tf.timeout.map(|t| t.as_secs()), "streaming terraform command");
 
     let mut child = cmd.spawn().map_err(|e| {
         if e.kind() == std::io::ErrorKind::NotFound {
@@ -144,29 +152,48 @@ where
         source: std::io::Error::other("no stdout"),
     })?;
 
-    let mut reader = BufReader::new(stdout).lines();
+    let stream_and_wait = async {
+        let mut reader = BufReader::new(stdout).lines();
 
-    while let Some(line) = reader.next_line().await.map_err(|e| Error::Io {
-        message: format!("failed to read stdout line: {e}"),
-        source: e,
-    })? {
-        trace!(%line, "stream line");
-        match serde_json::from_str::<JsonLogLine>(&line) {
-            Ok(log_line) => handler(log_line),
-            Err(e) => {
-                warn!(%line, error = %e, "failed to parse streaming json line, skipping");
+        while let Some(line) = reader.next_line().await.map_err(|e| Error::Io {
+            message: format!("failed to read stdout line: {e}"),
+            source: e,
+        })? {
+            trace!(%line, "stream line");
+            match serde_json::from_str::<JsonLogLine>(&line) {
+                Ok(log_line) => handler(log_line),
+                Err(e) => {
+                    warn!(%line, error = %e, "failed to parse streaming json line, skipping");
+                }
             }
         }
-    }
 
-    let output = child.wait_with_output().await.map_err(|e| Error::Io {
-        message: format!("failed to wait for terraform: {e}"),
-        source: e,
-    })?;
+        child.wait_with_output().await.map_err(|e| Error::Io {
+            message: format!("failed to wait for terraform: {e}"),
+            source: e,
+        })
+    };
+
+    let output = if let Some(duration) = tf.timeout {
+        match tokio::time::timeout(duration, stream_and_wait).await {
+            Ok(result) => result?,
+            Err(_) => {
+                warn!(
+                    timeout_seconds = duration.as_secs(),
+                    "streaming terraform command timed out"
+                );
+                return Err(Error::Timeout {
+                    timeout_seconds: duration.as_secs(),
+                });
+            }
+        }
+    } else {
+        stream_and_wait.await?
+    };
 
     let stderr = String::from_utf8_lossy(&output.stderr).to_string();
     let exit_code = output.status.code().unwrap_or(-1);
-    let success = output.status.success();
+    let success = allowed_exit_codes.contains(&exit_code);
 
     debug!(exit_code, success, "streaming terraform command completed");
 

--- a/tests/lifecycle.rs
+++ b/tests/lifecycle.rs
@@ -466,9 +466,14 @@ async fn streaming_apply() {
     InitCommand::new().execute(&tf).await.unwrap();
 
     let mut events: Vec<JsonLogLine> = Vec::new();
-    let result = stream_terraform(&tf, ApplyCommand::new().auto_approve().json(), |line| {
-        events.push(line);
-    })
+    let result = stream_terraform(
+        &tf,
+        ApplyCommand::new().auto_approve().json(),
+        &[0],
+        |line| {
+            events.push(line);
+        },
+    )
     .await
     .unwrap();
 


### PR DESCRIPTION
## Summary
- `stream_terraform` now respects `Terraform::timeout`, wrapping the streaming loop in `tokio::time::timeout` and returning `Error::Timeout` on expiry (matches `exec.rs` behavior)
- Added `allowed_exit_codes: &[i32]` parameter so callers can accept non-zero exits (e.g. `plan -detailed-exitcode` returns 2 for changes present) instead of hardcoded `status.success()`
- Updated all call sites: doc examples, integration test, example binary, README

## Test plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] All 95 unit tests pass
- [x] All 46 doc tests pass
- [x] `cargo doc --no-deps --all-features` builds cleanly

Closes #45, closes #46