### PR TITLE
refactor: consolidate -input=false injection into TerraformCommand trait

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -16,6 +16,27 @@ pub trait TerraformCommand: Send + Sync {
     /// For example: `["init", "-upgrade", "-backend-config=key=value"]`.
     fn args(&self) -> Vec<String>;
 
+    /// Whether this command supports the `-input=false` flag.
+    ///
+    /// Defaults to `false`. Commands that accept `-input` (init, plan, apply,
+    /// destroy, import, refresh) should override this to return `true`.
+    fn supports_input(&self) -> bool {
+        false
+    }
+
+    /// Build the argument list with `-input=false` injected when appropriate.
+    ///
+    /// Calls [`args`](TerraformCommand::args) and, if `tf.no_input` is set
+    /// and [`supports_input`](TerraformCommand::supports_input) returns `true`,
+    /// inserts `-input=false` after the subcommand name.
+    fn prepare_args(&self, tf: &Terraform) -> Vec<String> {
+        let mut args = self.args();
+        if tf.no_input && self.supports_input() {
+            args.insert(1, "-input=false".to_string());
+        }
+        args
+    }
+
     /// Execute this command against the given Terraform client.
     fn execute(
         &self,

--- a/src/commands/apply.rs
+++ b/src/commands/apply.rs
@@ -162,12 +162,12 @@ impl TerraformCommand for ApplyCommand {
         args
     }
 
+    fn supports_input(&self) -> bool {
+        true
+    }
+
     async fn execute(&self, tf: &Terraform) -> Result<CommandOutput> {
-        let mut args = self.args();
-        if tf.no_input {
-            args.insert(1, "-input=false".to_string());
-        }
-        exec::run_terraform(tf, args).await
+        exec::run_terraform(tf, self.prepare_args(tf)).await
     }
 }
 

--- a/src/commands/destroy.rs
+++ b/src/commands/destroy.rs
@@ -138,12 +138,12 @@ impl TerraformCommand for DestroyCommand {
         args
     }
 
+    fn supports_input(&self) -> bool {
+        true
+    }
+
     async fn execute(&self, tf: &Terraform) -> Result<CommandOutput> {
-        let mut args = self.args();
-        if tf.no_input {
-            args.insert(1, "-input=false".to_string());
-        }
-        exec::run_terraform(tf, args).await
+        exec::run_terraform(tf, self.prepare_args(tf)).await
     }
 }
 

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -108,12 +108,12 @@ impl TerraformCommand for ImportCommand {
         args
     }
 
+    fn supports_input(&self) -> bool {
+        true
+    }
+
     async fn execute(&self, tf: &Terraform) -> Result<CommandOutput> {
-        let mut args = self.args();
-        if tf.no_input {
-            args.insert(1, "-input=false".to_string());
-        }
-        exec::run_terraform(tf, args).await
+        exec::run_terraform(tf, self.prepare_args(tf)).await
     }
 }
 

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -137,12 +137,12 @@ impl TerraformCommand for InitCommand {
         args
     }
 
+    fn supports_input(&self) -> bool {
+        true
+    }
+
     async fn execute(&self, tf: &Terraform) -> Result<CommandOutput> {
-        let mut args = self.args();
-        if tf.no_input {
-            args.insert(1, "-input=false".to_string());
-        }
-        exec::run_terraform(tf, args).await
+        exec::run_terraform(tf, self.prepare_args(tf)).await
     }
 }
 

--- a/src/commands/plan.rs
+++ b/src/commands/plan.rs
@@ -190,12 +190,12 @@ impl TerraformCommand for PlanCommand {
         args
     }
 
+    fn supports_input(&self) -> bool {
+        true
+    }
+
     async fn execute(&self, tf: &Terraform) -> Result<CommandOutput> {
-        let mut args = self.args();
-        if tf.no_input {
-            args.insert(1, "-input=false".to_string());
-        }
-        exec::run_terraform_allow_exit_codes(tf, args, &[0, 2]).await
+        exec::run_terraform_allow_exit_codes(tf, self.prepare_args(tf), &[0, 2]).await
     }
 }
 

--- a/src/commands/refresh.rs
+++ b/src/commands/refresh.rs
@@ -131,12 +131,12 @@ impl TerraformCommand for RefreshCommand {
         args
     }
 
+    fn supports_input(&self) -> bool {
+        true
+    }
+
     async fn execute(&self, tf: &Terraform) -> Result<CommandOutput> {
-        let mut args = self.args();
-        if tf.no_input {
-            args.insert(1, "-input=false".to_string());
-        }
-        exec::run_terraform(tf, args).await
+        exec::run_terraform(tf, self.prepare_args(tf)).await
     }
 }
 

--- a/src/streaming.rs
+++ b/src/streaming.rs
@@ -102,15 +102,7 @@ where
     C: TerraformCommand,
     F: FnMut(JsonLogLine),
 {
-    let mut args = command.args();
-
-    // Inject -input=false for commands that support it (same as the command's execute())
-    if tf.no_input {
-        let subcmd = args.first().map(String::as_str).unwrap_or("");
-        if matches!(subcmd, "init" | "plan" | "apply" | "destroy" | "import") {
-            args.insert(1, "-input=false".to_string());
-        }
-    }
+    let args = command.prepare_args(tf);
 
     let mut cmd = TokioCommand::new(&tf.binary);
 


### PR DESCRIPTION
## Summary
- Added `supports_input()` and `prepare_args()` default methods to the `TerraformCommand` trait
- Replaced duplicated `if tf.no_input { args.insert(...) }` boilerplate in 6 command `execute()` methods (init, plan, apply, destroy, import, refresh)
- Replaced hardcoded `matches!(subcmd, "init" | "plan" | ...)` list in `streaming.rs` with `command.prepare_args(tf)`
- New commands that support `-input=false` now just override `supports_input()` to return `true`

## Test plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] All 95 unit tests pass
- [x] All 46 doc tests pass

Closes #47