### PR TITLE
fix: use Error::Json variant for serde parse failures

### DIFF
--- a/src/commands/output.rs
+++ b/src/commands/output.rs
@@ -119,16 +119,16 @@ impl TerraformCommand for OutputCommand {
         if self.json {
             if self.name.is_some() {
                 let value: crate::types::output::OutputValue = serde_json::from_str(&output.stdout)
-                    .map_err(|e| crate::error::Error::ParseError {
-                        message: format!("failed to parse output json: {e}"),
+                    .map_err(|e| crate::error::Error::Json {
+                        message: "failed to parse output json".to_string(),
+                        source: e,
                     })?;
                 return Ok(OutputResult::Single(value));
             }
             let values: HashMap<String, crate::types::output::OutputValue> =
-                serde_json::from_str(&output.stdout).map_err(|e| {
-                    crate::error::Error::ParseError {
-                        message: format!("failed to parse output json: {e}"),
-                    }
+                serde_json::from_str(&output.stdout).map_err(|e| crate::error::Error::Json {
+                    message: "failed to parse output json".to_string(),
+                    source: e,
                 })?;
             return Ok(OutputResult::Json(values));
         }

--- a/src/commands/show.rs
+++ b/src/commands/show.rs
@@ -109,8 +109,9 @@ impl TerraformCommand for ShowCommand {
         #[cfg(feature = "json")]
         if self.plan_file.is_some() {
             let plan: crate::types::plan::PlanRepresentation = serde_json::from_str(&output.stdout)
-                .map_err(|e| crate::error::Error::ParseError {
-                    message: format!("failed to parse plan json: {e}"),
+                .map_err(|e| crate::error::Error::Json {
+                    message: "failed to parse plan json".to_string(),
+                    source: e,
                 })?;
             return Ok(ShowResult::Plan(Box::new(plan)));
         }
@@ -118,10 +119,9 @@ impl TerraformCommand for ShowCommand {
         #[cfg(feature = "json")]
         {
             let state: crate::types::state::StateRepresentation =
-                serde_json::from_str(&output.stdout).map_err(|e| {
-                    crate::error::Error::ParseError {
-                        message: format!("failed to parse state json: {e}"),
-                    }
+                serde_json::from_str(&output.stdout).map_err(|e| crate::error::Error::Json {
+                    message: "failed to parse state json".to_string(),
+                    source: e,
                 })?;
             Ok(ShowResult::State(state))
         }

--- a/src/commands/validate.rs
+++ b/src/commands/validate.rs
@@ -75,8 +75,9 @@ impl TerraformCommand for ValidateCommand {
         // validate returns exit code 1 for invalid config, but with -json
         // it still writes valid JSON to stdout. Accept both exit codes.
         let output = exec::run_terraform_allow_exit_codes(tf, self.args(), &[0, 1]).await?;
-        serde_json::from_str(&output.stdout).map_err(|e| crate::error::Error::ParseError {
-            message: format!("failed to parse validate json: {e}"),
+        serde_json::from_str(&output.stdout).map_err(|e| crate::error::Error::Json {
+            message: "failed to parse validate json".to_string(),
+            source: e,
         })
     }
 }

--- a/src/commands/version.rs
+++ b/src/commands/version.rs
@@ -60,8 +60,9 @@ impl TerraformCommand for VersionCommand {
 
     async fn execute(&self, tf: &Terraform) -> Result<VersionInfo> {
         let output = exec::run_terraform(tf, self.args()).await?;
-        serde_json::from_str(&output.stdout).map_err(|e| crate::error::Error::ParseError {
-            message: format!("failed to parse version json: {e}"),
+        serde_json::from_str(&output.stdout).map_err(|e| crate::error::Error::Json {
+            message: "failed to parse version json".to_string(),
+            source: e,
         })
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -23,13 +23,6 @@ pub enum Error {
         stderr: String,
     },
 
-    /// Failed to parse command output.
-    #[error("failed to parse terraform output: {message}")]
-    ParseError {
-        /// Description of what failed to parse.
-        message: String,
-    },
-
     /// IO error during subprocess execution.
     #[error("io error: {message}")]
     Io {


### PR DESCRIPTION
## Summary
- Switched all 6 `serde_json` parse error sites from `Error::ParseError` to `Error::Json`, preserving the underlying `serde_json::Error` via `#[source]`
- Removed the now-unused `Error::ParseError` variant
- Affected commands: version, validate, output (2 sites), show (2 sites)

## Test plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] All 95 unit tests pass
- [x] All 46 doc tests pass

Closes #48