### PR TITLE
feat: add Display impls for CommandOutput and OutputResult

### DIFF
--- a/src/commands/output.rs
+++ b/src/commands/output.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::fmt;
 
 use crate::Terraform;
 use crate::command::TerraformCommand;
@@ -23,6 +24,25 @@ pub enum OutputResult {
     Single(crate::types::output::OutputValue),
     /// Plain command output (no `-json` or `-raw`).
     Plain(exec::CommandOutput),
+}
+
+impl fmt::Display for OutputResult {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            OutputResult::Raw(s) => write!(f, "{s}"),
+            #[cfg(feature = "json")]
+            OutputResult::Single(v) => {
+                let pretty = serde_json::to_string_pretty(v).map_err(|_| fmt::Error)?;
+                write!(f, "{pretty}")
+            }
+            #[cfg(feature = "json")]
+            OutputResult::Json(map) => {
+                let pretty = serde_json::to_string_pretty(map).map_err(|_| fmt::Error)?;
+                write!(f, "{pretty}")
+            }
+            OutputResult::Plain(output) => write!(f, "{output}"),
+        }
+    }
 }
 
 /// Command for reading Terraform output values.
@@ -173,5 +193,55 @@ mod tests {
         let args = cmd.args();
         // Name should be the last positional argument
         assert_eq!(args.last().unwrap(), "endpoint");
+    }
+
+    #[test]
+    fn display_raw() {
+        let result = OutputResult::Raw("10.0.1.5".to_string());
+        assert_eq!(result.to_string(), "10.0.1.5");
+    }
+
+    #[test]
+    fn display_plain() {
+        let output = exec::CommandOutput {
+            stdout: "some output\n".to_string(),
+            stderr: String::new(),
+            exit_code: 0,
+            success: true,
+        };
+        let result = OutputResult::Plain(output);
+        assert_eq!(result.to_string(), "some output");
+    }
+
+    #[cfg(feature = "json")]
+    #[test]
+    fn display_single() {
+        let value = crate::types::output::OutputValue {
+            sensitive: false,
+            output_type: serde_json::json!("string"),
+            value: serde_json::json!("10.0.1.5"),
+        };
+        let result = OutputResult::Single(value);
+        let displayed = result.to_string();
+        assert!(displayed.contains("\"value\": \"10.0.1.5\""));
+        assert!(displayed.contains("\"sensitive\": false"));
+    }
+
+    #[cfg(feature = "json")]
+    #[test]
+    fn display_json_map() {
+        let mut map = HashMap::new();
+        map.insert(
+            "ip".to_string(),
+            crate::types::output::OutputValue {
+                sensitive: false,
+                output_type: serde_json::json!("string"),
+                value: serde_json::json!("1.2.3.4"),
+            },
+        );
+        let result = OutputResult::Json(map);
+        let displayed = result.to_string();
+        assert!(displayed.contains("\"ip\""));
+        assert!(displayed.contains("\"value\": \"1.2.3.4\""));
     }
 }

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::process::Stdio;
 
 use tokio::process::Command as TokioCommand;
@@ -24,6 +25,12 @@ impl CommandOutput {
     #[must_use]
     pub fn stdout_lines(&self) -> Vec<&str> {
         self.stdout.lines().collect()
+    }
+}
+
+impl fmt::Display for CommandOutput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.stdout.trim())
     }
 }
 
@@ -152,4 +159,42 @@ async fn run_terraform_inner(
         exit_code,
         success,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_command_output_trims_whitespace() {
+        let output = CommandOutput {
+            stdout: "  hello world  \n".to_string(),
+            stderr: String::new(),
+            exit_code: 0,
+            success: true,
+        };
+        assert_eq!(output.to_string(), "hello world");
+    }
+
+    #[test]
+    fn display_command_output_empty() {
+        let output = CommandOutput {
+            stdout: String::new(),
+            stderr: String::new(),
+            exit_code: 0,
+            success: true,
+        };
+        assert_eq!(output.to_string(), "");
+    }
+
+    #[test]
+    fn display_command_output_multiline() {
+        let output = CommandOutput {
+            stdout: "line1\nline2\nline3\n".to_string(),
+            stderr: String::new(),
+            exit_code: 0,
+            success: true,
+        };
+        assert_eq!(output.to_string(), "line1\nline2\nline3");
+    }
 }


### PR DESCRIPTION
## Summary

- Add `Display` impl for `CommandOutput` that displays `stdout` trimmed of leading/trailing whitespace
- Add `Display` impl for `OutputResult` that displays the value regardless of variant: `Raw` shows the raw string, `Single`/`Json` use `serde_json::to_string_pretty`, and `Plain` delegates to `CommandOutput`'s `Display`
- The `Single` and `Json` match arms are feature-gated behind `#[cfg(feature = "json")]` to match the enum variants

Closes #49

## Test plan

- [x] Unit tests for `CommandOutput::fmt` covering trimmed output, empty output, and multiline output
- [x] Unit tests for `OutputResult::fmt` covering `Raw`, `Plain`, `Single` (json feature), and `Json` (json feature) variants
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --lib --all-features` passes (102 tests)
- [x] `cargo test --doc --all-features` passes (46 doc tests)