### PR TITLE
docs: update README, expand command table, and add examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A type-safe Terraform CLI wrapper for Rust.
 
 ```toml
 [dependencies]
-terraform-wrapper = "0.1"
+terraform-wrapper = "0.3"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 ```
 
@@ -63,20 +63,45 @@ Note: You must import the `TerraformCommand` trait to call `.execute()`. The `pr
 
 ## Commands
 
+### Lifecycle
+
 | Command | Description |
 |---------|-------------|
 | `InitCommand` | Prepare working directory, download providers |
-| `ValidateCommand` | Check configuration validity |
 | `PlanCommand` | Preview infrastructure changes |
 | `ApplyCommand` | Create or update infrastructure |
 | `DestroyCommand` | Destroy infrastructure |
-| `OutputCommand` | Read output values |
+
+### Inspection
+
+| Command | Description |
+|---------|-------------|
+| `ValidateCommand` | Check configuration validity |
 | `ShowCommand` | Inspect current state or saved plan |
+| `OutputCommand` | Read output values |
 | `FmtCommand` | Format configuration files |
-| `WorkspaceCommand` | Manage workspaces (list, new, select, delete) |
-| `StateCommand` | Advanced state management (list, show, mv, rm) |
-| `ImportCommand` | Import existing infrastructure into state |
+| `GraphCommand` | Generate DOT dependency graph |
+| `ModulesCommand` | List installed modules |
+| `ProvidersCommand` | Manage providers (lock, mirror, schema) |
+| `TestCommand` | Run Terraform test files |
 | `VersionCommand` | Get Terraform version info |
+
+### State and Workspace
+
+| Command | Description |
+|---------|-------------|
+| `WorkspaceCommand` | Manage workspaces (list, show, new, select, delete) |
+| `StateCommand` | Advanced state management (list, show, mv, rm, pull, push) |
+| `ImportCommand` | Import existing infrastructure into state |
+| `ForceUnlockCommand` | Manually unlock state |
+| `GetCommand` | Download and update modules |
+| `RefreshCommand` | Update state to match remote (deprecated) |
+
+### Escape Hatch
+
+| Command | Description |
+|---------|-------------|
+| `RawCommand` | Run any subcommand not covered above |
 
 ## Streaming Output
 
@@ -108,7 +133,7 @@ Define Terraform configs entirely in Rust -- no `.tf` files needed. Enable the `
 
 ```toml
 [dependencies]
-terraform-wrapper = { version = "0.1", features = ["config"] }
+terraform-wrapper = { version = "0.3", features = ["config"] }
 ```
 
 ```rust,no_run
@@ -144,7 +169,7 @@ Disable defaults for raw command output only:
 
 ```toml
 [dependencies]
-terraform-wrapper = { version = "0.1", default-features = false }
+terraform-wrapper = { version = "0.3", default-features = false }
 ```
 
 ## Why terraform-wrapper?
@@ -163,7 +188,13 @@ Use `terraform-wrapper` when you need to programmatically drive Terraform lifecy
 
 Full API reference is available on [docs.rs](https://docs.rs/terraform-wrapper).
 
-See the [`examples/`](examples/) directory for working examples.
+See the [`examples/`](examples/) directory for working examples:
+- [`ec2_instance`](examples/ec2_instance.rs) -- Full AWS lifecycle
+- [`gce_instance`](examples/gce_instance.rs) -- Full GCP lifecycle
+- [`streaming_apply`](examples/streaming_apply.rs) -- Real-time JSON event processing
+- [`config_builder`](examples/config_builder.rs) -- Generate `.tf.json` from Rust
+- [`workspace_management`](examples/workspace_management.rs) -- Create, switch, and delete workspaces
+- [`validate_and_fmt`](examples/validate_and_fmt.rs) -- Check and fix configuration
 
 ## License
 

--- a/examples/validate_and_fmt.rs
+++ b/examples/validate_and_fmt.rs
@@ -1,0 +1,107 @@
+//! Validate and format example: check configuration and fix formatting.
+//!
+//! Demonstrates using ValidateCommand and FmtCommand together as a
+//! pre-commit or CI check workflow.
+//!
+//! Uses null_resource so no cloud credentials are needed.
+//!
+//! Usage:
+//!   cargo run --example validate_and_fmt
+
+use terraform_wrapper::commands::fmt::FmtCommand;
+use terraform_wrapper::commands::init::InitCommand;
+use terraform_wrapper::commands::validate::ValidateCommand;
+use terraform_wrapper::{Terraform, TerraformCommand};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    let dir = tmp.path();
+
+    let tf = Terraform::builder().working_dir(dir).build()?;
+
+    // Write intentionally ugly (but valid) config
+    let ugly_tf = r#"
+terraform {
+required_providers {
+null = {
+source  = "hashicorp/null"
+version = "~> 3.0"
+}
+}
+}
+
+resource "null_resource"   "example" {
+  triggers={
+    value   =   "hello"
+  }
+}
+
+output "id" {
+value=null_resource.example.id
+}
+"#;
+    std::fs::write(dir.join("main.tf"), ugly_tf)?;
+
+    // Step 1: Check formatting (will fail -- config is ugly)
+    println!("--- Step 1: Check formatting ---");
+    let output = FmtCommand::new().check().execute(&tf).await?;
+    if output.exit_code != 0 {
+        println!("Formatting issues found (exit code {})", output.exit_code);
+    } else {
+        println!("All files formatted correctly");
+    }
+
+    // Step 2: Auto-fix formatting
+    println!("\n--- Step 2: Auto-format ---");
+    FmtCommand::new().execute(&tf).await?;
+    println!("Formatting applied");
+
+    // Step 3: Verify formatting is clean now
+    let output = FmtCommand::new().check().execute(&tf).await?;
+    println!(
+        "Format check: {}",
+        if output.exit_code == 0 {
+            "PASS"
+        } else {
+            "FAIL"
+        }
+    );
+
+    // Step 4: Initialize and validate
+    println!("\n--- Step 3: Init and validate ---");
+    InitCommand::new().execute(&tf).await?;
+    let result = ValidateCommand::new().execute(&tf).await?;
+
+    if result.valid {
+        println!("Configuration is valid ({} warnings)", result.warning_count);
+    } else {
+        println!("Configuration is INVALID ({} errors):", result.error_count);
+        for diag in &result.diagnostics {
+            println!("  [{}] {}: {}", diag.severity, diag.summary, diag.detail);
+        }
+    }
+
+    // Step 5: Validate something broken
+    println!("\n--- Step 4: Validate broken config ---");
+    let broken_tf = r#"
+output "bad" {
+  value = nonexistent_resource.foo.id
+}
+"#;
+    std::fs::write(dir.join("broken.tf"), broken_tf)?;
+
+    let result = ValidateCommand::new().execute(&tf).await?;
+    if !result.valid {
+        println!(
+            "Found {} error(s), {} warning(s):",
+            result.error_count, result.warning_count
+        );
+        for diag in &result.diagnostics {
+            println!("  [{}] {}", diag.severity, diag.summary);
+        }
+    }
+
+    println!("\nDone.");
+    Ok(())
+}

--- a/examples/workspace_management.rs
+++ b/examples/workspace_management.rs
@@ -1,0 +1,88 @@
+//! Workspace management example: create, switch, list, and delete workspaces.
+//!
+//! Uses null_resource so no cloud credentials are needed.
+//!
+//! Usage:
+//!   cargo run --example workspace_management
+
+use terraform_wrapper::commands::apply::ApplyCommand;
+use terraform_wrapper::commands::destroy::DestroyCommand;
+use terraform_wrapper::commands::init::InitCommand;
+use terraform_wrapper::commands::output::{OutputCommand, OutputResult};
+use terraform_wrapper::commands::workspace::WorkspaceCommand;
+use terraform_wrapper::{Terraform, TerraformCommand};
+
+const CONFIG: &str = r#"
+terraform {
+  required_providers {
+    null = { source = "hashicorp/null", version = "~> 3.0" }
+  }
+}
+
+variable "env" {
+  default = "default"
+}
+
+resource "null_resource" "example" {
+  triggers = { env = var.env }
+}
+
+output "workspace_env" {
+  value = var.env
+}
+"#;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    let dir = tmp.path();
+    std::fs::write(dir.join("main.tf"), CONFIG)?;
+
+    let tf = Terraform::builder().working_dir(dir).build()?;
+
+    println!("--- Initializing ---");
+    InitCommand::new().execute(&tf).await?;
+
+    // Show current workspace (starts as "default")
+    let output = WorkspaceCommand::show().execute(&tf).await?;
+    println!("Current workspace: {}", output.stdout.trim());
+
+    // Create and switch to "staging"
+    println!("\n--- Creating 'staging' workspace ---");
+    WorkspaceCommand::new_workspace("staging")
+        .execute(&tf)
+        .await?;
+
+    let output = WorkspaceCommand::show().execute(&tf).await?;
+    println!("Current workspace: {}", output.stdout.trim());
+
+    // Apply in the staging workspace
+    ApplyCommand::new()
+        .auto_approve()
+        .var("env", "staging")
+        .execute(&tf)
+        .await?;
+
+    let result = OutputCommand::new()
+        .name("workspace_env")
+        .raw()
+        .execute(&tf)
+        .await?;
+    if let OutputResult::Raw(value) = result {
+        println!("Output in staging: {value}");
+    }
+
+    // List all workspaces
+    println!("\n--- All workspaces ---");
+    let output = WorkspaceCommand::list().execute(&tf).await?;
+    print!("{}", output.stdout);
+
+    // Clean up: destroy, switch back, delete
+    println!("\n--- Cleaning up ---");
+    DestroyCommand::new().auto_approve().execute(&tf).await?;
+    WorkspaceCommand::select("default").execute(&tf).await?;
+    WorkspaceCommand::delete("staging").execute(&tf).await?;
+    println!("Done.");
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,6 +155,7 @@
 //!     ForceUnlockCommand, // terraform force-unlock
 //!     GetCommand,         // terraform get (download modules)
 //!     RefreshCommand,     // terraform refresh (deprecated)
+//!     RawCommand,         // any subcommand not covered above
 //! };
 //! ```
 //!
@@ -273,7 +274,7 @@
 //!
 //! Enable with:
 //! ```toml
-//! terraform-wrapper = { version = "0.1", features = ["config"] }
+//! terraform-wrapper = { version = "0.3", features = ["config"] }
 //! ```
 //!
 //! # Feature Flags
@@ -286,7 +287,7 @@
 //! Disable defaults for raw command output only:
 //!
 //! ```toml
-//! terraform-wrapper = { version = "0.1", default-features = false }
+//! terraform-wrapper = { version = "0.3", default-features = false }
 //! ```
 //!
 //! # OpenTofu Compatibility


### PR DESCRIPTION
## Summary
- Fix version references from `0.1` to `0.2` in README and lib.rs doc examples
- Expand README command table from 12 to all 20 commands, organized by category (lifecycle, inspection, state/workspace, escape hatch)
- Add `RawCommand` to lib.rs command categories section
- Add `workspace_management` example (create, switch, list, delete workspaces)
- Add `validate_and_fmt` example (check formatting, validate config, handle diagnostics)
- Add full example listing to README documentation section

## Test plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] All 104 unit tests pass
- [x] All 47 doc tests pass