### PR TITLE
docs: expand TerraformConfig builder documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,12 +143,17 @@ use serde_json::json;
 # fn example() -> std::io::Result<()> {
 let config = TerraformConfig::new()
     .required_provider("aws", "hashicorp/aws", "~> 5.0")
+    .backend("s3", json!({ "bucket": "my-tf-state", "key": "state", "region": "us-west-2" }))
     .provider("aws", json!({ "region": "us-west-2" }))
+    .variable("instance_type", json!({ "type": "string", "default": "t3.micro" }))
+    .data("aws_ami", "latest", json!({ "most_recent": true, "owners": ["amazon"] }))
     .resource("aws_instance", "web", json!({
-        "ami": "ami-0c55b159",
-        "instance_type": "t3.micro"
+        "ami": "${data.aws_ami.latest.id}",
+        "instance_type": "${var.instance_type}"
     }))
-    .output("id", json!({ "value": "${aws_instance.web.id}" }));
+    .local("common_tags", json!({ "ManagedBy": "terraform-wrapper" }))
+    .module("vpc", json!({ "source": "terraform-aws-modules/vpc/aws", "version": "~> 5.0" }))
+    .output("instance_id", json!({ "value": "${aws_instance.web.id}" }));
 
 let dir = config.write_to_tempdir()?;
 // Terraform::builder().working_dir(dir.path()).build()?;
@@ -156,7 +161,7 @@ let dir = config.write_to_tempdir()?;
 # }
 ```
 
-See the [`config_builder` example](examples/config_builder.rs) for a complete working example.
+See the [`config_builder` example](examples/config_builder.rs) and the [`TerraformConfig` API docs](https://docs.rs/terraform-wrapper/latest/terraform_wrapper/config/struct.TerraformConfig.html) for full details.
 
 ## Features
 

--- a/examples/config_builder.rs
+++ b/examples/config_builder.rs
@@ -3,6 +3,13 @@
 //! No .tf files needed -- generates .tf.json, runs init/apply, reads outputs,
 //! then destroys. Uses null_resource so no cloud credentials are needed.
 //!
+//! Demonstrates all available TerraformConfig builder methods:
+//! required_provider, provider, variable, data, resource, local, output.
+//!
+//! Note: backend and module are also supported but not shown here because
+//! backend requires real remote state configuration and module requires
+//! a valid module path to run successfully.
+//!
 //! Usage:
 //!   cargo run --example config_builder --features config
 
@@ -16,23 +23,32 @@ use terraform_wrapper::{Terraform, TerraformCommand};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Define infrastructure in code
+    // Define infrastructure in code using all block types that work
+    // without external dependencies
     let config = TerraformConfig::new()
         .required_provider("null", "hashicorp/null", "~> 3.0")
+        .provider("null", json!({}))
+        .variable(
+            "greeting",
+            json!({ "type": "string", "default": "Hello from terraform-wrapper!" }),
+        )
+        .data(
+            "null_data_source",
+            "greeting_data",
+            json!({ "inputs": { "greeting": "${var.greeting}" } }),
+        )
         .resource(
             "null_resource",
             "greeting",
             json!({ "triggers": { "message": "${var.greeting}" } }),
         )
-        .variable(
-            "greeting",
-            json!({ "type": "string", "default": "Hello from terraform-wrapper!" }),
-        )
+        .local("app_name", json!("config-builder-example"))
         .output("message", json!({ "value": "${var.greeting}" }))
         .output(
             "resource_id",
             json!({ "value": "${null_resource.greeting.id}" }),
-        );
+        )
+        .output("app_name", json!({ "value": "${local.app_name}" }));
 
     // Write to a temp directory
     let dir = config.write_to_tempdir()?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,6 +4,12 @@
 //! alongside HCL. This module provides a builder API to construct configs
 //! entirely in Rust and serialize them to `.tf.json`.
 //!
+//! Supported block types: [`required_provider`](TerraformConfig::required_provider),
+//! [`backend`](TerraformConfig::backend), [`provider`](TerraformConfig::provider),
+//! [`variable`](TerraformConfig::variable), [`data`](TerraformConfig::data),
+//! [`resource`](TerraformConfig::resource), [`local`](TerraformConfig::local),
+//! [`module`](TerraformConfig::module), [`output`](TerraformConfig::output).
+//!
 //! # Example
 //!
 //! ```rust
@@ -12,10 +18,16 @@
 //!
 //! let config = TerraformConfig::new()
 //!     .required_provider("null", "hashicorp/null", "~> 3.0")
+//!     .provider("null", json!({}))
+//!     .variable("name", json!({ "type": "string", "default": "world" }))
+//!     .data("null_data_source", "values", json!({
+//!         "inputs": { "greeting": "hello" }
+//!     }))
 //!     .resource("null_resource", "example", json!({
 //!         "triggers": { "value": "hello" }
 //!     }))
-//!     .variable("name", json!({ "type": "string", "default": "world" }))
+//!     .local("tag", json!("test"))
+//!     .module("child", json!({ "source": "./modules/child" }))
 //!     .output("id", json!({ "value": "${null_resource.example.id}" }));
 //!
 //! let json = config.to_json_pretty().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -245,7 +245,18 @@
 //! # Config Builder
 //!
 //! With the `config` feature, define Terraform configurations entirely in Rust.
-//! No `.tf` files needed -- generates `.tf.json` that Terraform processes natively:
+//! No `.tf` files needed -- generates `.tf.json` that Terraform processes natively.
+//!
+//! Available builder methods:
+//! [`required_provider`](config::TerraformConfig::required_provider),
+//! [`backend`](config::TerraformConfig::backend),
+//! [`provider`](config::TerraformConfig::provider),
+//! [`variable`](config::TerraformConfig::variable),
+//! [`data`](config::TerraformConfig::data),
+//! [`resource`](config::TerraformConfig::resource),
+//! [`local`](config::TerraformConfig::local),
+//! [`module`](config::TerraformConfig::module),
+//! [`output`](config::TerraformConfig::output).
 //!
 //! ```rust
 //! # #[cfg(feature = "config")]
@@ -255,17 +266,36 @@
 //!
 //! let config = TerraformConfig::new()
 //!     .required_provider("aws", "hashicorp/aws", "~> 5.0")
-//!     .provider("aws", json!({ "region": "us-west-2" }))
-//!     .resource("aws_instance", "web", json!({
-//!         "ami": "ami-0c55b159",
-//!         "instance_type": "${var.instance_type}"
+//!     .backend("s3", json!({
+//!         "bucket": "my-tf-state",
+//!         "key": "terraform.tfstate",
+//!         "region": "us-west-2"
 //!     }))
+//!     .provider("aws", json!({ "region": "us-west-2" }))
 //!     .variable("instance_type", json!({
 //!         "type": "string", "default": "t3.micro"
 //!     }))
-//!     .output("id", json!({ "value": "${aws_instance.web.id}" }));
+//!     .data("aws_ami", "latest", json!({
+//!         "most_recent": true,
+//!         "owners": ["amazon"]
+//!     }))
+//!     .resource("aws_instance", "web", json!({
+//!         "ami": "${data.aws_ami.latest.id}",
+//!         "instance_type": "${var.instance_type}"
+//!     }))
+//!     .local("common_tags", json!({
+//!         "Environment": "production",
+//!         "ManagedBy": "terraform-wrapper"
+//!     }))
+//!     .module("vpc", json!({
+//!         "source": "terraform-aws-modules/vpc/aws",
+//!         "version": "~> 5.0",
+//!         "cidr": "10.0.0.0/16"
+//!     }))
+//!     .output("instance_id", json!({
+//!         "value": "${aws_instance.web.id}"
+//!     }));
 //!
-//! // Write to a tempdir for ephemeral use
 //! let dir = config.write_to_tempdir()?;
 //! // Terraform::builder().working_dir(dir.path()).build()?;
 //! # Ok(())


### PR DESCRIPTION
## Summary

- **lib.rs rustdoc**: Expanded Config Builder section to show all 9 builder methods (`required_provider`, `backend`, `provider`, `variable`, `data`, `resource`, `local`, `module`, `output`) with linked API references. The rustdoc is now the canonical, most complete reference for the config builder API.
- **config.rs module doc**: Added a summary listing all supported block types with intra-doc links, and expanded the example to demonstrate all methods.
- **README**: Expanded the Config Builder snippet to show all available methods. Added a link to the `TerraformConfig` API docs on docs.rs rather than duplicating full documentation.
- **config_builder example**: Added `.provider()`, `.data()`, `.local()` calls and an output referencing `local.app_name`. Backend and module are noted in the doc comment as supported but omitted from the runnable example since they require external dependencies.

Fixes #58